### PR TITLE
Ci/bookworm iso

### DIFF
--- a/.github/workflows/build-iso.yml
+++ b/.github/workflows/build-iso.yml
@@ -1,10 +1,19 @@
 name: Build GOST OS ISO
-on: { workflow_dispatch: {}, push: { branches: [ main, ci/trixie-iso ], paths: [ 'auto/**', 'config/**', '.github/workflows/build-iso.yml' ] } }
+on:
+  workflow_dispatch: {}
+  push:
+    branches:
+      - main
+      - ci/bookworm-iso
+    paths:
+      - 'auto/**'
+      - 'config/**'
+      - '.github/workflows/build-iso.yml'
 jobs:
   build:
     runs-on: ubuntu-latest
     container:
-      image: debian:trixie-slim
+      image: debian:bookworm-slim
       options: --privileged
     steps:
       - uses: actions/checkout@v4
@@ -22,12 +31,15 @@ jobs:
       - name: Configure
         run: ./auto/config
       - name: Build
-        env: { LB_FORCE: "true" }
         run: ./auto/build
       - name: Upload ISO
         uses: actions/upload-artifact@v4
-        with: { name: gostos-trixie-amd64.iso, path: live-image-amd64.hybrid.iso }
+        with:
+          name: gostos-bookworm-amd64.iso
+          path: live-image-amd64.hybrid.iso
       - name: Upload logs
         if: always()
         uses: actions/upload-artifact@v4
-        with: { name: live-build-logs, path: build.log }
+        with:
+          name: live-build-logs
+          path: build.log

--- a/auto/build
+++ b/auto/build
@@ -1,4 +1,4 @@
 #!/bin/bash
 set -euo pipefail
 # Wygodny log do diagnostyki
-lb build 2>&1 | tee build.log
+lb build --force 2>&1 | tee build.log

--- a/auto/config
+++ b/auto/config
@@ -3,7 +3,7 @@ set -euo pipefail
 lb config noauto \
   --mode debian \
   --architectures amd64 \
-  --distribution trixie \
+  ---distribution bookworm \
   --binary-images iso-hybrid \
   --debian-installer false \
   --archive-areas "main contrib non-free non-free-firmware" \

--- a/config/archives/live.list.chroot
+++ b/config/archives/live.list.chroot
@@ -1,3 +1,3 @@
-deb http://deb.debian.org/debian trixie main contrib non-free non-free-firmware
-deb http://deb.debian.org/debian trixie-updates main contrib non-free non-free-firmware
-deb http://security.debian.org/debian-security trixie-security main contrib non-free non-free-firmware
+deb http://deb.debian.org/debian bookworm main contrib non-free non-free-firmware
+deb http://deb.debian.org/debian bookworm-updates main contrib non-free non-free-firmware
+deb http://security.debian.org/debian-security bookworm-security main contrib non-free non-free-firmware

--- a/config/hooks/00-sources.hook.chroot
+++ b/config/hooks/00-sources.hook.chroot
@@ -1,8 +1,8 @@
 #!/bin/sh
 set -e
 cat >/etc/apt/sources.list <<'EOF'
-deb http://deb.debian.org/debian trixie main contrib non-free non-free-firmware
-deb http://deb.debian.org/debian trixie-updates main contrib non-free non-free-firmware
-deb http://security.debian.org/debian-security trixie-security main contrib non-free non-free-firmware
+deb http://deb.debian.org/debian bookworm main contrib non-free non-free-firmware
+deb http://deb.debian.org/debian bookworm-updates main contrib non-free non-free-firmware
+deb http://security.debian.org/debian-security bookworm-security main contrib non-free non-free-firmware
 EOF
 apt-get update


### PR DESCRIPTION
Switch GOST OS pipeline to Debian 12 bookworm and fix build:
- Update auto/config to use --distribution bookworm
- Update apt sources (live.list.chroot and 00-sources.hook.chroot) to bookworm, bookworm-updates, and bookworm-security
- Modify auto/build to call `lb build --force` instead of using LB_FORCE env
- Update GitHub Actions workflow: use debian:bookworm-slim container, remove LB_FORCE env, and rename ISO artifact to gostos-bookworm-amd64.iso

This should resolve the argument list too long errors and produce a working ISO.